### PR TITLE
Fixes #33. isset will always be true on an empty array.

### DIFF
--- a/ReduxCore/inc/classes/class-redux-transients.php
+++ b/ReduxCore/inc/classes/class-redux-transients.php
@@ -22,7 +22,7 @@ if ( ! class_exists( 'Redux_Transients', false ) ) {
 		public function get() {
 			$core = $this->core();
 
-			if ( ! isset( $core->transients ) ) {
+			if ( empty( $core->transients ) ) {
 				$core->transients = get_option( $core->args['opt_name'] . '-transients', array() );
 			}
 		}


### PR DESCRIPTION
`$core->transients` is initialized with an empty array. This means `! isset( $core->transients )` will never be true, resulting in `$core->transients` always being an empty array. It can be modified and even saved correctly, but at the beginning of the next request it will be set to empty again.