### PR TITLE
Fix warning Undefined index: REMOTE_ADDR

### DIFF
--- a/redux-core/inc/classes/class-redux-helpers.php
+++ b/redux-core/inc/classes/class-redux-helpers.php
@@ -704,7 +704,10 @@ if ( ! class_exists( 'Redux_Helpers', false ) ) {
 		 * @return string
 		 */
 		public static function get_hash() {
-			return md5( network_site_url() . '-' . Redux_Core::$server['REMOTE_ADDR'] );
+			$remote_addr = isset(Redux_Core::$server['REMOTE_ADDR'])
+				? Redux_Core::$server['REMOTE_ADDR']
+				: '127.0.0.1';
+			return md5( network_site_url() . '-' . $remote_addr );
 		}
 
 		/**


### PR DESCRIPTION
When running wp-cron.php via Unix cronjob the message Undefined index: REMOTE_ADDR in /wp-content/plugins/redux-framework/redux-core/inc/classes/class-redux-helpers.php line 707 will appear.