### PR TITLE
Eliminate undefined offset notice by checking for array key.

### DIFF
--- a/redux-core/inc/classes/class-redux-output.php
+++ b/redux-core/inc/classes/class-redux-output.php
@@ -387,7 +387,7 @@ if ( ! class_exists( 'Redux_Output', false ) ) {
 						$return       = $core->required_class->compare_value_dependencies( $parent_value, $check_value, $operation );
 					} elseif ( is_array( $field['required'][0] ) ) {
 						foreach ( $field['required'] as $required ) {
-							if ( ! is_array( $required[0] ) && 3 === count( $required ) ) {
+							if ( isset( $required[0] ) && ! is_array( $required[0] ) && 3 === count( $required ) ) {
 								$parent_value = isset( $GLOBALS[ $core->args['global_variable'] ][ $required[0] ] ) ? $GLOBALS[ $core->args['global_variable'] ][ $required[0] ] : '';
 								$check_value  = $required[2];
 								$operation    = $required[1];


### PR DESCRIPTION
Just adding a simple check to make sure the array key exists before checking if it is an array to avoid the potential of a notice being generated.