### PR TITLE
don't load directories

### DIFF
--- a/redux-core/inc/classes/class-redux-filesystem.php
+++ b/redux-core/inc/classes/class-redux-filesystem.php
@@ -620,7 +620,7 @@ if ( ! class_exists( 'Redux_Filesystem', false ) ) {
 
 			try {
 				ob_start();
-				if ( $this->file_exists( $abs_path ) ) {
+				if ( $this->file_exists( $abs_path ) && preg_match('/\.php$/',$abs_path)) {
 					require_once $abs_path;
 				}
 				$contents = ob_get_clean();


### PR DESCRIPTION
due to some filesystems nature ( proemintantly VIP ),
require_once was trying to load a directory
I'm not sure why $abs_path was a directory,
albeit from seeing in the code, the redux autoload class puts $abs_path as /uploads/ + /redux/version , so it might start from there,
while this is a temporary fix for wp-admin not to break in some instances, i'm not sure if other issues are present in the plugin.